### PR TITLE
Add support for sifting `Map`, `Set`, iterables

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ const [oneYearOlds, lessThan40, theRest] = sift(
 
 ### `sift()` a `Map` or `Set`
 
+`Set` example:
+
 ```js
 import { sift } from 'sift-r'
 import { lt } from 'match-iz'
@@ -191,6 +193,38 @@ const [oneYearOlds, lessThan40, theRest] = sift(
 // theRest ===
 //   new Set([
 //     { user: 'fred', age: 40, active: true }
+//   ])
+```
+
+`Map` example:
+
+```js
+import { sift } from 'sift-r'
+import { lt } from 'match-iz'
+
+const [oneYearOlds, lessThan40, theRest] = sift(
+  new Map([
+    [0, { user: 'barney', age: 36, active: false }],
+    [1, { user: 'fred', age: 40, active: true }],
+    [2, { user: 'pebbles', age: 1, active: false }]
+  ]),
+  { age: 1, active: false },
+  { age: lt(40) }
+)
+
+// oneYearOlds ===
+//   new Map([
+//     [2, { user: 'pebbles', age: 1, active: false }]
+//   ])
+
+// lessThan40 ===
+//   new Map([
+//     [0, { user: 'barney', age: 36, active: false }]
+//   ])
+
+// theRest ===
+//   new Map([
+//     [1, { user: 'fred', age: 40, active: true }]
 //   ])
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@
     /></a>
 </p>
 
-A complement to [match-iz](https://github.com/shuckster/match-iz) for filtering objects and arrays based on a `match-iz` pattern.
+A complement to [match-iz](https://github.com/shuckster/match-iz) for filtering objects, arrays, and `Map`/`Set` based on a `match-iz` pattern.
 
 - 🗺 [byPattern() for map/filter](#bypattern)
 - 📥 [sift() an object](#sift-an-object)
 - 📁 [sift() an array](#sift-an-array)
 - 🗂 [sift() an array into multiple buckets](#sift-an-array-into-multiple-buckets)
+- 🗺 [sift() a Map or Set](#sift-a-map-or-set)
 - 📖 [Documentation](https://github.com/shuckster/sift-r/wiki)
 - 📀 [Install / Use](#install--use)
 
@@ -159,6 +160,38 @@ const [oneYearOlds, lessThan40, theRest] = sift(
 
 // theRest ===
 //   [{ user: 'fred', age: 40, active: true }]
+```
+
+### `sift()` a `Map` or `Set`
+
+```js
+import { sift } from 'sift-r'
+import { lt } from 'match-iz'
+
+const [oneYearOlds, lessThan40, theRest] = sift(
+  new Set([
+    { user: 'barney', age: 36, active: false },
+    { user: 'fred', age: 40, active: true },
+    { user: 'pebbles', age: 1, active: false }
+  ]),
+  { age: 1, active: false },
+  { age: lt(40) }
+)
+
+// oneYearOlds ===
+//   new Set([
+//     { user: 'pebbles', age: 1, active: false }
+//   ])
+
+// lessThan40 ===
+//   new Set([
+//     { user: 'barney', age: 36, active: false }
+//   ])
+
+// theRest ===
+//   new Set([
+//     { user: 'fred', age: 40, active: true }
+//   ])
 ```
 
 ## Install / Use

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A complement to [match-iz](https://github.com/shuckster/match-iz) for filtering 
 - 📁 [sift() an array](#sift-an-array)
 - 🗂 [sift() an array into multiple buckets](#sift-an-array-into-multiple-buckets)
 - 🗺 [sift() a Map or Set](#sift-a-map-or-set)
+- 🔢 [sift() an iterable](#sift-an-iterable)
 - 📖 [Documentation](https://github.com/shuckster/sift-r/wiki)
 - 📀 [Install / Use](#install--use)
 
@@ -226,6 +227,34 @@ const [oneYearOlds, lessThan40, theRest] = sift(
 //   new Map([
 //     [1, { user: 'fred', age: 40, active: true }]
 //   ])
+```
+
+### `sift()` an iterable
+
+```js
+import { sift } from 'sift-r'
+import { lt } from 'match-iz'
+
+function* flintstones() {
+  yield { user: 'barney', age: 36, active: false }
+  yield { user: 'fred', age: 40, active: true }
+  yield { user: 'pebbles', age: 1, active: false }
+}
+
+const [oneYearOlds, lessThan40, theRest] = sift(
+  flintstones(),
+  { age: 1, active: false },
+  { age: lt(40) }
+)
+
+// oneYearOlds ===
+//   [{ user: 'pebbles', age: 1, active: false }]
+
+// lessThan40 ===
+//   [{ user: 'barney', age: 36, active: false }]
+
+// theRest ===
+//   [{ user: 'fred', age: 40, active: true }]
 ```
 
 ## Install / Use

--- a/src/sift-r.mjs
+++ b/src/sift-r.mjs
@@ -4,6 +4,9 @@ const { match, against, when, otherwise } = lib
 const { not, allOf, firstOf, every, gte } = lib
 const { isArray, isPojo, isFunction, isString } = lib
 
+const isSet = x => x instanceof Set
+const isMap = x => x instanceof Map
+
 const isArrayOfBinaryArrays = allOf(
   isArray,
   every(isArray),
@@ -28,9 +31,19 @@ export function sift(input, ...optionalSchema) {
     when([isArray, not(isArray)])(siftArrayAgainstPattern),
     when(allOf(firstOf(isArray), { length: gte(2) }))(siftArrayAgainstPatterns),
 
+    // Set
+    when([isSet, allOf(not(isSet), not(isMap))])(siftSetAgainstPattern),
+    when(allOf(firstOf(isSet), { length: gte(2) }))(siftSetAgainstPatterns),
+
+    // Map
+    when([isMap, allOf(not(isSet), not(isMap))])(siftMapAgainstPattern),
+    when(allOf(firstOf(isMap), { length: gte(2) }))(siftMapAgainstPatterns),
+
     // Passthru
     when([isPojo])(([input]) => [{}, input]),
     when([isArray])(([input]) => [[], input]),
+    when([isSet])(([input]) => [new Set([]), input]),
+    when([isMap])(([input]) => [new Map([]), input]),
     otherwise(([input]) => [undefined, input])
   )
 }
@@ -85,6 +98,46 @@ const siftArrayAgainstPatterns = ([arr, ...patterns]) => {
 }
 
 //
+// Set
+//
+
+const siftSetAgainstPattern = ([set, pattern]) =>
+  siftSetAgainstPatterns([set, pattern])
+
+const siftSetAgainstPatterns = ([set, ...patterns]) => {
+  const results = Array.from({ length: patterns.length }).map(() => new Set())
+  const noMatch = new Set()
+  set.forEach(
+    against(
+      ...patterns.map((pattern, idx) => when(pattern)(addToSet(results[idx]))),
+      otherwise(addToSet(noMatch))
+    )
+  )
+  return [...results, noMatch]
+}
+
+//
+// Map
+//
+
+const siftMapAgainstPattern = ([map, pattern]) =>
+  siftMapAgainstPatterns([map, pattern])
+
+const siftMapAgainstPatterns = ([map, ...patterns]) => {
+  const results = Array.from({ length: patterns.length }).map(() => new Map())
+  const noMatch = new Map()
+  map.forEach((value, key) =>
+    match(value)(
+      ...patterns.map((pattern, idx) =>
+        when(pattern)(addToMap(results[idx], key))
+      ),
+      otherwise(addToMap(noMatch, key))
+    )
+  )
+  return [...results, noMatch]
+}
+
+//
 // Pojo
 //
 
@@ -133,6 +186,14 @@ const siftPojoAgainstPatterns = ([pojo, arr]) => {
 
 function pushTo(arr) {
   return item => arr.push(item)
+}
+
+function addToSet(set) {
+  return item => set.add(item)
+}
+
+function addToMap(map, key) {
+  return value => map.set(key, value)
 }
 
 function assignEntryTo(obj) {

--- a/src/sift-r.mjs
+++ b/src/sift-r.mjs
@@ -9,7 +9,7 @@ const isMap = x => x instanceof Map
 
 // TODO: can bring in from `match-iz` in the future
 const isIterable = x =>
-  x != null && [x[Symbol.iterator], x.next].every(x => typeof x === 'function')
+  x != null && [x[Symbol.iterator], x.next].every(isFunction)
 
 const isArrayOfBinaryArrays = allOf(
   isArray,

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -282,18 +282,6 @@ const testCases = [
               }
             ]
           ]
-        },
-        {
-          input: [
-            [
-              { user: 'barney', age: 36, active: false },
-              { user: 'fred', age: 40, active: true },
-              { user: 'pebbles', age: 1, active: false }
-            ],
-            { active: false, age: pluck(isNumber) },
-            { active: true, age: pluck(isNumber) }
-          ],
-          expecting: [[36, 1], [40], []]
         }
       ],
       run: (assertCase, input) => {
@@ -319,6 +307,287 @@ const testCases = [
             [{ user: 'pebbles', age: 1, active: false }],
             [{ user: 'barney', age: 36, active: false }],
             [{ user: 'fred', age: 40, active: true }]
+          ]
+        },
+        {
+          input: [
+            [
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ],
+            { active: false, age: pluck(isNumber) },
+            { active: true, age: pluck(isNumber) }
+          ],
+          expecting: [[36, 1], [40], []]
+        }
+      ],
+      run: (assertCase, input) => {
+        assertCase(sift(...input))
+      }
+    }
+  ],
+  //
+  // Set
+  //
+  [
+    'siftSetAgainstPattern',
+    {
+      cases: [
+        {
+          input: [new Set(['header', 1, '# header']), isString],
+          expecting: [new Set(['header', '# header']), new Set([1])]
+        },
+        {
+          input: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            { age: 1, active: false }
+          ],
+          expecting: [
+            new Set([{ user: 'pebbles', age: 1, active: false }]),
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true }
+            ])
+          ]
+        },
+        {
+          input: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            { active: false }
+          ],
+          expecting: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            new Set([{ user: 'fred', age: 40, active: true }])
+          ]
+        },
+        {
+          input: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            o => o.active
+          ],
+          expecting: [
+            new Set([{ user: 'fred', age: 40, active: true }]),
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'pebbles', age: 1, active: false }
+            ])
+          ]
+        },
+        {
+          input: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            { active: false, age: pluck(isNumber) }
+          ],
+          expecting: [
+            new Set([36, 1]),
+            new Set([
+              {
+                user: 'fred',
+                age: 40,
+                active: true
+              }
+            ])
+          ]
+        }
+      ],
+      run: (assertCase, input) => {
+        assertCase(sift(...input))
+      }
+    }
+  ],
+  [
+    'siftSetAgainstPatterns',
+    {
+      cases: [
+        {
+          input: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            { age: 1, active: false },
+            { age: lt(40) }
+          ],
+          expecting: [
+            new Set([{ user: 'pebbles', age: 1, active: false }]),
+            new Set([{ user: 'barney', age: 36, active: false }]),
+            new Set([{ user: 'fred', age: 40, active: true }])
+          ]
+        },
+        {
+          input: [
+            new Set([
+              { user: 'barney', age: 36, active: false },
+              { user: 'fred', age: 40, active: true },
+              { user: 'pebbles', age: 1, active: false }
+            ]),
+            { active: false, age: pluck(isNumber) },
+            { active: true, age: pluck(isNumber) }
+          ],
+          expecting: [new Set([36, 1]), new Set([40]), new Set([])]
+        }
+      ],
+      run: (assertCase, input) => {
+        assertCase(sift(...input))
+      }
+    }
+  ],
+  //
+  // Map
+  //
+  [
+    'siftMapAgainstPattern',
+    {
+      cases: [
+        {
+          input: [
+            new Map([
+              [0, 'header'],
+              [1, 1],
+              [2, '# header']
+            ]),
+            isString
+          ],
+          expecting: [
+            new Map([
+              [0, 'header'],
+              [2, '# header']
+            ]),
+            new Map([[1, 1]])
+          ]
+        },
+        {
+          input: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            { age: 1, active: false }
+          ],
+          expecting: [
+            new Map([[2, { user: 'pebbles', age: 1, active: false }]]),
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }]
+            ])
+          ]
+        },
+        {
+          input: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            { active: false }
+          ],
+          expecting: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            new Map([[1, { user: 'fred', age: 40, active: true }]])
+          ]
+        },
+        {
+          input: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            o => o.active
+          ],
+          expecting: [
+            new Map([[1, { user: 'fred', age: 40, active: true }]]),
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ])
+          ]
+        },
+        {
+          input: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            { active: false, age: pluck(isNumber) }
+          ],
+          expecting: [
+            new Map([
+              [0, 36],
+              [2, 1]
+            ]),
+            new Map([[1, { user: 'fred', age: 40, active: true }]])
+          ]
+        }
+      ],
+      run: (assertCase, input) => {
+        assertCase(sift(...input))
+      }
+    }
+  ],
+  [
+    'siftMapAgainstPatterns',
+    {
+      cases: [
+        {
+          input: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            { age: 1, active: false },
+            { age: lt(40) }
+          ],
+          expecting: [
+            new Map([[2, { user: 'pebbles', age: 1, active: false }]]),
+            new Map([[0, { user: 'barney', age: 36, active: false }]]),
+            new Map([[1, { user: 'fred', age: 40, active: true }]])
+          ]
+        },
+        {
+          input: [
+            new Map([
+              [0, { user: 'barney', age: 36, active: false }],
+              [1, { user: 'fred', age: 40, active: true }],
+              [2, { user: 'pebbles', age: 1, active: false }]
+            ]),
+            { active: false, age: pluck(isNumber) },
+            { active: true, age: pluck(isNumber) }
+          ],
+          expecting: [
+            new Map([
+              [0, 36],
+              [2, 1]
+            ]),
+            new Map([[1, 40]]),
+            new Map([])
           ]
         }
       ],
@@ -458,8 +727,12 @@ function makeTester(expecting, message) {
 }
 
 testCases.forEach(([description, testCase = {}]) => {
-  const { cases = [], run = () => {} } = testCase
-  cases.forEach(({ input, expecting }, index) => {
+  const { skip, cases = [], run = () => {} } = testCase
+  if (skip) return
+
+  cases.forEach(({ skip, input, expecting }, index) => {
+    if (skip) return
+
     const message = `\n\n^\n| Test case failed in [${index}]: ${description}\n`
     const test = makeTester(expecting, message)
     run(test, input)

--- a/tests/run.mjs
+++ b/tests/run.mjs
@@ -597,6 +597,36 @@ const testCases = [
     }
   ],
   //
+  // Iterable
+  //
+  [
+    'siftIterableAgainstPatterns',
+    {
+      cases: [
+        {
+          input: [flintstones(), { age: 1, active: false }, { age: lt(40) }],
+          expecting: [
+            [{ user: 'pebbles', age: 1, active: false }],
+            [{ user: 'barney', age: 36, active: false }],
+            [{ user: 'fred', age: 40, active: true }]
+          ]
+        },
+        {
+          input: [
+            flintstones(),
+            { active: false, age: pluck(isNumber) },
+            { active: true, age: pluck(isNumber) }
+          ],
+          expecting: [[36, 1], [40], []]
+        }
+      ],
+      run: (assertCase, input) => {
+        assertCase(sift(...input))
+      }
+    }
+  ],
+
+  //
   // Passthru
   //
   [
@@ -711,6 +741,12 @@ const testCases = [
     }
   ]
 ]
+
+function* flintstones() {
+  yield { user: 'barney', age: 36, active: false }
+  yield { user: 'fred', age: 40, active: true }
+  yield { user: 'pebbles', age: 1, active: false }
+}
 
 function makeTester(expecting, message) {
   return saw => {


### PR DESCRIPTION

`Set` example:

```js
import { sift } from 'sift-r'
import { lt } from 'match-iz'

const [oneYearOlds, lessThan40, theRest] = sift(
  new Set([
    { user: 'barney', age: 36, active: false },
    { user: 'fred', age: 40, active: true },
    { user: 'pebbles', age: 1, active: false }
  ]),
  { age: 1, active: false },
  { age: lt(40) }
)

// oneYearOlds ===
//   new Set([
//     { user: 'pebbles', age: 1, active: false }
//   ])

// lessThan40 ===
//   new Set([
//     { user: 'barney', age: 36, active: false }
//   ])

// theRest ===
//   new Set([
//     { user: 'fred', age: 40, active: true }
//   ])
```

`Map` example:

```js
import { sift } from 'sift-r'
import { lt } from 'match-iz'

const [oneYearOlds, lessThan40, theRest] = sift(
  new Map([
    [0, { user: 'barney', age: 36, active: false }],
    [1, { user: 'fred', age: 40, active: true }],
    [2, { user: 'pebbles', age: 1, active: false }]
  ]),
  { age: 1, active: false },
  { age: lt(40) }
)

// oneYearOlds ===
//   new Map([
//     [2, { user: 'pebbles', age: 1, active: false }]
//   ])

// lessThan40 ===
//   new Map([
//     [0, { user: 'barney', age: 36, active: false }]
//   ])

// theRest ===
//   new Map([
//     [1, { user: 'fred', age: 40, active: true }]
//   ])
```
So with `Map` we sift only on values, never keys.